### PR TITLE
Add machine learning for excessive set overhead

### DIFF
--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -20,23 +20,65 @@ class APCuL1 extends L1
         return 'lcache:' . $this->pool . ':' . $address->serialize();
     }
 
+    public function getKeyOverhead(Address $address)
+    {
+        // @TODO: Consider subtracting APCu's native hits tracker but
+        // decrementing the overhead by existing hits when an item is set. This
+        // would make hits cheaper but writes more expensive.
+
+        $apcu_key = $this->getLocalKey($address);
+        $overhead = apcu_fetch($apcu_key . ':overhead', $success);
+        if ($success) {
+            return $overhead;
+        }
+        return 0;
+    }
+
     public function setWithExpiration($event_id, Address $address, $value, $created, $expiration = null)
     {
         $apcu_key = $this->getLocalKey($address);
+
         // Don't overwrite local entries that are even newer.
         $entry = apcu_fetch($apcu_key);
         if ($entry !== false && $entry->event_id > $event_id) {
             return true;
         }
         $entry = new Entry($event_id, $this->pool, $address, $value, REQUEST_TIME, $expiration);
-        return apcu_store($apcu_key, $entry, is_null($expiration) ? 0 : $expiration);
+        $success = apcu_store($apcu_key, $entry, is_null($expiration) ? 0 : $expiration);
+
+        // If not setting a negative cache entry, increment the key's overhead.
+        if (!is_null($value)) {
+            apcu_inc($apcu_key . ':overhead', 1, $overhead_success);
+            if (!$overhead_success) {
+                // @codeCoverageIgnoreStart
+                apcu_store($apcu_key . ':overhead', 1);
+                // @codeCoverageIgnoreEnd
+            }
+        }
+
+        return $success;
+    }
+
+    public function isNegativeCache(Address $address)
+    {
+        $apcu_key = $this->getLocalKey($address);
+        $entry = apcu_fetch($apcu_key, $success);
+        return ($success && is_null($entry->value));
     }
 
     public function getEntry(Address $address)
     {
         $apcu_key = $this->getLocalKey($address);
-        $entry = apcu_fetch($apcu_key, $success);
 
+        // Decrement the key's overhead.
+        apcu_dec($apcu_key . ':overhead', 1, $overhead_success);
+        if (!$overhead_success) {
+            // @codeCoverageIgnoreStart
+            apcu_store($apcu_key . ':overhead', -1);
+            // @codeCoverageIgnoreEnd
+        }
+
+        $entry = apcu_fetch($apcu_key, $success);
         // Handle failed reads.
         if (!$success) {
             $this->recordMiss();
@@ -48,16 +90,15 @@ class APCuL1 extends L1
     }
 
     // @TODO: Remove APCIterator support once we only support PHP 7+
-    protected function getIterator($prefix)
+    protected function getIterator($pattern, $format = APC_ITER_ALL)
     {
-        $pattern = '/^' . $prefix . '.*/';
         if (class_exists('APCIterator')) {
             // @codeCoverageIgnoreStart
-            return new \APCIterator('user', $pattern);
+            return new \APCIterator('user', $pattern, $format);
             // @codeCoverageIgnoreEnd
         }
         // @codeCoverageIgnoreStart
-        return new \APCUIterator($pattern);
+        return new \APCUIterator($pattern, $format);
         // @codeCoverageIgnoreEnd
     }
 
@@ -68,7 +109,8 @@ class APCuL1 extends L1
             return apcu_clear_cache();
         } elseif ($address->isEntireBin()) {
             $prefix = $this->getLocalKey($address);
-            $matching = $this->getIterator($prefix);
+            $pattern = '/^' . $prefix . '.*/';
+            $matching = $this->getIterator($pattern, APC_ITER_KEY);
             if (!$matching) {
                 // @codeCoverageIgnoreStart
                 return false;

--- a/src/Integrated.php
+++ b/src/Integrated.php
@@ -8,7 +8,7 @@ final class Integrated
     protected $l2;
     protected $overhead_threshold;
 
-    public function __construct($l1, $l2, $overhead_threshold = 100)
+    public function __construct($l1, $l2, $overhead_threshold = null)
     {
         $this->l1 = $l1;
         $this->l2 = $l2;
@@ -17,29 +17,31 @@ final class Integrated
 
     public function set(Address $address, $value, $ttl = null, array $tags = [])
     {
-        $key_overhead = $this->l1->getKeyOverhead($address);
+        if (!is_null($this->overhead_threshold)) {
+            $key_overhead = $this->l1->getKeyOverhead($address);
 
-        // Check if this key is known to have excessive overhead.
-        $excess = $key_overhead - $this->overhead_threshold;
-        if ($excess >= 0) {
-            // If there's already an L1 negative cache entry, simply skip the write.
-            if ($this->l1->isNegativeCache($address)) {
-                return null;
+            // Check if this key is known to have excessive overhead.
+            $excess = $key_overhead - $this->overhead_threshold;
+            if ($excess >= 0) {
+                // If there's already an L1 negative cache entry, simply skip the write.
+                if ($this->l1->isNegativeCache($address)) {
+                    return null;
+                }
+
+                // Otherwise, delete the item in L2
+                // and create a local negative cache entry.
+                $event_id = $this->l2->delete($this->l1->getPool(), $address);
+                if (!is_null($event_id)) {
+                    $this->l1->set($event_id, $address, $value, $ttl);
+                }
+
+                // Retain this negative cache item for a number of minutes
+                // equivalent to the number of excessive sets over the
+                // threshold, plus one minute.
+                $expiration = $_SERVER['REQUEST_TIME'] + ($excess + 1) * 60;
+                $this->l1->setWithExpiration($event_id, $address, null, $_SERVER['REQUEST_TIME'], $expiration);
+                return $event_id;
             }
-
-            // Otherwise, delete the item in L2
-            // and create a local negative cache entry.
-            $event_id = $this->l2->delete($this->l1->getPool(), $address);
-            if (!is_null($event_id)) {
-                $this->l1->set($event_id, $address, $value, $ttl);
-            }
-
-            // Retain this negative cache item for a number of minutes
-            // equivalent to the number of excessive sets over the
-            // threshold, plus one minute.
-            $expiration = $_SERVER['REQUEST_TIME'] + ($excess + 1) * 60;
-            $this->l1->setWithExpiration($event_id, $address, null, $_SERVER['REQUEST_TIME'], $expiration);
-            return $event_id;
         }
 
         $expiration = is_null($ttl) ? null : $_SERVER['REQUEST_TIME'] + $ttl;

--- a/src/L1.php
+++ b/src/L1.php
@@ -31,6 +31,8 @@ abstract class L1 extends LX
         return $this->setWithExpiration($event_id, $address, $value, REQUEST_TIME, is_null($ttl) ? null : $ttl);
     }
 
+    abstract public function isNegativeCache(Address $address);
+    abstract public function getKeyOverhead(Address $address);
     abstract public function setWithExpiration($event_id, Address $address, $value, $created, $expiration = null);
     abstract public function delete($event_id, Address $address);
 }

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -691,6 +691,81 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->assertEquals(1, $l2->countGarbage());
     }
 
+    protected function performHitSetCounterTest($l1)
+    {
+        $pool = new Integrated($l1, new StaticL2());
+        $myaddr = new Address('mybin', 'mykey');
+
+        $this->assertEquals(0, $l1->getKeyOverhead($myaddr));
+        $pool->set($myaddr, 'myvalue');
+        $this->assertEquals(1, $l1->getKeyOverhead($myaddr));
+        $pool->get($myaddr);
+        $this->assertEquals(0, $l1->getKeyOverhead($myaddr));
+        $pool->set($myaddr, 'myvalue2');
+        $this->assertEquals(1, $l1->getKeyOverhead($myaddr));
+
+        // An unknown get should create negative overhead, generally
+        // in anticipation of a set.
+        $myaddr2 = new Address('mybin', 'mykey2');
+        $pool->get($myaddr2);
+        $this->assertEquals(-1, $l1->getKeyOverhead($myaddr2));
+    }
+
+
+    public function testStaticL1Counters()
+    {
+        $this->performHitSetCounterTest(new StaticL1());
+    }
+
+    public function testAPCuL1Counters()
+    {
+        $this->performHitSetCounterTest(new APCuL1('counters'));
+    }
+
+    protected function performExcessiveOverheadSkippingTest($l1)
+    {
+        $pool = new Integrated($l1, new StaticL2(), 2);
+        $myaddr = new Address('mybin', 'mykey');
+
+        // These should go through entirely.
+        $this->assertNotNull($pool->set($myaddr, 'myvalue1'));
+        $this->assertNotNull($pool->set($myaddr, 'myvalue2'));
+
+        // This should return an event_id but delete the item.
+        $this->assertNotNull($pool->set($myaddr, 'myvalue3'));
+        $this->assertFalse($pool->exists($myaddr));
+
+        // A few more sets to offset the existence check, which some L1s may
+        // treat as a hit. This should put us firmly in excessive territory.
+        $pool->set($myaddr, 'myvalue4');
+        $pool->set($myaddr, 'myvalue5');
+        $pool->set($myaddr, 'myvalue6');
+
+        // Now, with the local negative cache, these shouldn't even return
+        // an event_id.
+        $this->assertNull($pool->set($myaddr, 'myvalueA1'));
+        $this->assertNull($pool->set($myaddr, 'myvalueA2'));
+
+        // Test a lot of sets but with enough hits to drop below the threshold.
+        $myaddr2 = new Address('mybin', 'mykey2');
+        $this->assertNotNull($pool->set($myaddr2, 'myvalue'));
+        $this->assertNotNull($pool->set($myaddr2, 'myvalue'));
+        $this->assertEquals('myvalue', $pool->get($myaddr2));
+        $this->assertEquals('myvalue', $pool->get($myaddr2));
+        $this->assertNotNull($pool->set($myaddr2, 'myvalue'));
+        $this->assertNotNull($pool->set($myaddr2, 'myvalue'));
+    }
+
+    public function testStaticL1ExcessiveOverheadSkipping()
+    {
+        $this->performExcessiveOverheadSkippingTest(new StaticL1());
+    }
+
+    public function testAPCuL1ExcessiveOverheadSkipping()
+    {
+        $this->performExcessiveOverheadSkippingTest(new APCuL1('overhead'));
+    }
+
     /**
     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
     */


### PR DESCRIPTION
This branch does a few things:
1. Adds get vs. set tracking to L1 caches, expressed as a key overhead score that the integrated cache can request.
2. When there's a request to set a key+value, the integrated cache checks the current overhead score for the key. In the common case where there's been a miss and then a set, the overhead score would be at -1 before setting the new key (and zero immediately after).
3. If the overhead score (attempted gets versus sets) is high (say around 100) and the local L1 has a negative cache for the key, then it doesn't set anything, anywhere.
4. If the overhead score is high and there is no negative cache in the L1, delete the key and set a negative cache in the local L1 with an escalating expiration (depending on how excessive the overhead score is).

The effect is distributed decision-making my the local PHP-FPM pools for which keys aren't worth the time to store. There's a bit of back-and-forth as the nodes converge on the same decisions, but it should normalize within 1000 requests.
