### PR TITLE
Add simple API documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.sami-cache
+docs/api
 .DS_Store
 phpunit.xml
 vendor
 composer.lock
-build/
+build/logs
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 before_script:
   - echo 'apc.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - pear config-set preferred_state beta
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then (echo "no" | pecl install apcu) ; else (echo "no\nno" | pecl install channel://pecl.php.net/apcu-4.0.11) ; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then (yes | pecl install channel://pecl.php.net/apcu-5.1.5) ; else (echo "no\nno" | pecl install channel://pecl.php.net/apcu-4.0.11) ; fi
   - phpenv rehash
   - composer install
 
@@ -31,6 +31,8 @@ script:
 
 after_success:
   # Publish updated API documentation on every push to the master branch
+  - git config --global user.email $GITHUB_USER_EMAIL
+  - git config --global user.name "Travis LCache Documentation Bot"
   - build/scripts/publish-api-docs.sh
   # Generate coveralls code coverage
   - travis_retry php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
     - /^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*$/
 
 php:
+  - 5.6
   - 7.0
 
 sudo: false
@@ -19,7 +20,7 @@ cache:
 before_script:
   - echo 'apc.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - pear config-set preferred_state beta
-  - yes '' | pecl install apcu
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then (echo "no" | pecl install apcu) ; else (echo "no\nno" | pecl install channel://pecl.php.net/apcu-4.0.11) ; fi
   - phpenv rehash
   - composer install
 
@@ -29,4 +30,7 @@ script:
   - vendor/bin/phpunit
 
 after_success:
+  # Publish updated API documentation on every push to the master branch
+  - build/scripts/publish-api-docs.sh
+  # Generate coveralls code coverage
   - travis_retry php vendor/bin/coveralls -v

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # LCache
 Foundation Library for Coherent, Multi-Layer Caching
 
-## Testing
-
 [![Build Status](https://travis-ci.org/lcache/lcache.svg?branch=master)](https://travis-ci.org/lcache/lcache)
 [![Coverage Status](https://coveralls.io/repos/github/lcache/lcache/badge.svg?branch=master)](https://coveralls.io/github/lcache/lcache?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/lcache/lcache/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/lcache/lcache/?branch=master)
+[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://lcache.github.io/lcache/)
+[![API](https://img.shields.io/badge/api-latest-brightgreen.svg?style=flat)](https://lcache.github.io/lcache/api/master)
+[![License](https://poser.pugx.org/lcache/lcache/license)](https://packagist.org/packages/lcache/lcache)
 
-### On Fedora
+## Testing
 
  1. Install packages:
+ 
+    ** On Fedora: **
 
     ```
     sudo dnf install -y php-cli composer php-phpunit-PHPUnit php-phpunit-DbUnit php-pecl-apcu
+    ```
+    
+    ** On MacOS: **
+    
+    ```
+    brew install php70-xdebug 
+    brew install php70-opcache
+    brew install php70-apcu
     ```
 
  2. Enable APCu caching for the CLI:
@@ -19,6 +31,8 @@ Foundation Library for Coherent, Multi-Layer Caching
     ```
     echo "apc.enable_cli=1" | sudo tee -a /etc/php.d/40-apcu.ini
     ```
+    
+    Replace last argument with path to your php.ini. (`php -i | grep php.ini`)
 
  3. From the project root directory:
 
@@ -26,7 +40,7 @@ Foundation Library for Coherent, Multi-Layer Caching
     composer install
     composer test
     ```
-
+    
 ## Support
 
 LCache is maintained and sponsored by [Pantheon](https://pantheon.io/).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Foundation Library for Coherent, Multi-Layer Caching
 
  1. Install packages:
  
-    ** On Fedora: **
+    **On Fedora:**
 
     ```
-    sudo dnf install -y php-cli composer php-phpunit-PHPUnit php-phpunit-DbUnit php-pecl-apcu
+    sudo dnf install -y php-cli composer php-phpunit-PHPUnit php-phpunit-DbUnit php-pecl-apcu php-pecl-xdebug php-opcache
     ```
     
-    ** On MacOS: **
+    **On macOS:**
     
     ```
     brew install php70-xdebug 
@@ -26,13 +26,18 @@ Foundation Library for Coherent, Multi-Layer Caching
     brew install php70-apcu
     ```
 
- 2. Enable APCu caching for the CLI:
+ 2. Enable APCu caching for the CLI, if necessary:
 
     ```
     echo "apc.enable_cli=1" | sudo tee -a /etc/php.d/40-apcu.ini
     ```
     
-    Replace last argument with path to your php.ini. (`php -i | grep php.ini`)
+    Replace last argument with path to your php.ini. (`php -i | grep php.ini`).
+    This setting may already be enabled on your system; to find out, run:
+    ```
+    php -i | grep -i enable_cli
+    ```
+    You will see `apc.enable_cli => On => On` if it is enabled.
 
  3. From the project root directory:
 

--- a/build/scripts/publish-api-docs.sh
+++ b/build/scripts/publish-api-docs.sh
@@ -1,33 +1,41 @@
 #!/bin/bash
 
+# Check to make sure that our build environment is right. Skip with no error otherwise.
+test -n "$TRAVIS"                           || { echo "This script is only designed to be run on Travis."; exit 0; }
+test "$TRAVIS_BRANCH" == "master"           || { echo "Skipping docs update for branch $TRAVIS_BRANCH - docs only updated for master branch."; exit 0; }
+test "$TRAVIS_PULL_REQUEST" == "true"       || { echo "Skipping docs update -- not done on pull requests."; exit 0; }
+test "${TRAVIS_PHP_VERSION:0:3}" == "5.6"   || { echo "Skipping docs update for PHP $TRAVIS_PHP_VERSION -- only update for PHP 5.6 build."; exit 0; }
+test "$TRAVIS_REPO_SLUG" == "lcache/lcache" || { echo "Skipping docs update for repository $TRAVIS_REPO_SLUG -- do not build docs for forks."; exit 0; }
+
+# Check our requirements for running this script have been met.
+test -n "$GITHUB_TOKEN"                     || { echo "GITHUB_TOKEN environment variable must be set to run this script."; exit 1; }
+test -n "$(git config --global user.email)" || { echo 'Git user email not set. Use `git config --global user.email EMAIL`.'; exit 1; }
+test -n "$(git config --global user.name)"  || { echo 'Git user name not set. Use `git config --global user.name NAME`.'; exit 1; }
+
 # Ensure that we exit on failure, and echo lines as they are executed.
+# We don't need to see our sanity-checks get echoed, so we turn this on after they are done.
 set -ev
 
-# Check to make sure that our build environment is right.
-test "$TRAVIS_BRANCH" == "master" || (echo "Skipping docs update - docs only updated for master branch." && exit 0)
-test "$TRAVIS_PULL_REQUEST" == "true" || (echo "Skipping docs update -- not done on pull requests." && exit 0)
-test "${TRAVIS_PHP_VERSION:0:3}" == "5.6" || (echo "Skipping docs update -- only update for PHP 5.6 build." && exit 0)
-test "$TRAVIS_REPO_SLUG" == "lcache/lcache" || (echo "Skipping docs update -- do not build docs for forks." && exit 0)
-
-# Install Sami
+# Install Sami using the install script in composer.json
 composer sami-install
 
-# Build the API documentation
+# Build the API documentation using the api script in composer.json
 composer api
 
-# Identify the docs bot
-git config --global user.email $GITHUB_USER_EMAIL
-git config --global user.name "Travis LCache Documentation Bot"
-
 # Check out the gh-pages branch using our Github token (defined at https://travis-ci.org/lcache/lcache/settings)
-git clone --quiet --branch=gh-pages https://${GITHUB_TOKEN}@github.com/lcache/lcache $HOME/gh-pages > /dev/null
+API_BUILD_DIR="$HOME/.lcache-build/gh-pages"
+if [ ! -d "$API_BUILD_DIR" ]
+then
+  mkdir -p "$(dirname $API_BUILD_DIR)"
+  git clone --quiet --branch=gh-pages https://${GITHUB_TOKEN}@github.com/lcache/lcache "$API_BUILD_DIR" > /dev/null
+fi
 
 # Replace the old 'api' folder with the newly-built API documentation
-rm -rf $HOME/gh-pages/api
-cp -R docs/api $HOME/gh-pages
+rm -rf "$API_BUILD_DIR/api"
+cp -R docs/api "$API_BUILD_DIR"
 
 # Commit any changes to the documentation
-cd $HOME/gh-pages
+cd "$API_BUILD_DIR"
 git add -A api
-git commit -m "Update API documentation."
+git commit -m "Update API documentation from Travis build $TRAVIS_BUILD_NUMBER, '$TRAVIS_COMMIT'."
 git push

--- a/build/scripts/publish-api-docs.sh
+++ b/build/scripts/publish-api-docs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Ensure that we exit on failure, and echo lines as they are executed.
+set -ev
+
+# Check to make sure that our build environment is right.
+test "$TRAVIS_BRANCH" == "master" || (echo "Skipping docs update - docs only updated for master branch." && exit 0)
+test "$TRAVIS_PULL_REQUEST" == "true" || (echo "Skipping docs update -- not done on pull requests." && exit 0)
+test "${TRAVIS_PHP_VERSION:0:3}" == "5.6" || (echo "Skipping docs update -- only update for PHP 5.6 build." && exit 0)
+test "$TRAVIS_REPO_SLUG" == "lcache/lcache" || (echo "Skipping docs update -- do not build docs for forks." && exit 0)
+
+# Install Sami
+composer sami-install
+
+# Build the API documentation
+composer api
+
+# Identify the docs bot
+git config --global user.email $GITHUB_USER_EMAIL
+git config --global user.name "Travis LCache Documentation Bot"
+
+# Check out the gh-pages branch using our Github token (defined at https://travis-ci.org/lcache/lcache/settings)
+git clone --quiet --branch=gh-pages https://${GITHUB_TOKEN}@github.com/lcache/lcache $HOME/gh-pages > /dev/null
+
+# Replace the old 'api' folder with the newly-built API documentation
+rm -rf $HOME/gh-pages/api
+cp -R docs/api $HOME/gh-pages
+
+# Commit any changes to the documentation
+cd $HOME/gh-pages
+git add -A api
+git commit -m "Update API documentation."
+git push

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "squizlabs/php_codesniffer": "2.*"
     },
     "scripts": {
+        "cs": "phpcs --standard=PSR2 -n src",
+        "api": "PATH=$HOME/bin:$PATH sami.phar --ansi update sami-config.php",
+        "sami-install": "mkdir -p $HOME/bin && curl --output $HOME/bin/sami.phar http://get.sensiolabs.org/sami.phar && chmod +x $HOME/bin/sami.phar",
         "test": "phpunit"
     },
     "extra": {

--- a/sami-config.php
+++ b/sami-config.php
@@ -1,0 +1,31 @@
+<?php
+
+use Sami\Sami;
+use Sami\RemoteRepository\GitHubRemoteRepository;
+use Sami\Version\GitVersionCollection;
+use Symfony\Component\Finder\Finder;
+
+$dir = __DIR__ . '/src';
+
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->in($dir)
+;
+
+// generate documentation for all v2.0.* tags, the 2.0 branch, and the master one
+$versions = GitVersionCollection::create($dir)
+    ->addFromTags('v0.*.0')
+    ->addFromTags('v*.0.0')
+    ->add('master', 'master branch')
+;
+
+return new Sami($iterator, array(
+    'theme'                => 'default',
+    'versions'             => $versions,
+    'title'                => 'LCache API',
+    'build_dir'            => __DIR__.'/docs/api/%version%',
+    'cache_dir'            => __DIR__.'/.sami-cache/%version%',
+    'remote_repository'    => new GitHubRemoteRepository('lcache/lcache', __DIR__),
+    'default_opened_level' => 2,
+));

--- a/src/Address.php
+++ b/src/Address.php
@@ -2,10 +2,23 @@
 
 namespace LCache;
 
+/**
+ * Represents a specific address in a cache, or everything in one bin,
+ * or everything in the entire cache.
+ */
 final class Address implements \Serializable
 {
+    /** @var string|null */
     protected $bin;
+    /** @var string|null */
     protected $key;
+
+    /**
+     * Address constructor.
+     *
+     * @param string|null $bin
+     * @param string|null $key
+     */
     public function __construct($bin = null, $key = null)
     {
         assert(!is_null($bin) || is_null($key));
@@ -13,26 +26,48 @@ final class Address implements \Serializable
         $this->key = $key;
     }
 
+    /**
+     * Get the bin.
+     * @return string|null
+     */
     public function getBin()
     {
         return $this->bin;
     }
 
+    /**
+     * Get the key.
+     * @return string|null
+     */
     public function getKey()
     {
         return $this->key;
     }
 
+    /**
+     * Return true if address refers to everything in the entire bin.
+     * @return boolean
+     */
     public function isEntireBin()
     {
         return is_null($this->key);
     }
 
+    /**
+     * Return true if address refers to everything in the entire cache.
+     * @return boolean
+     */
     public function isEntireCache()
     {
         return is_null($this->bin);
     }
 
+    /**
+     * Return true if this object refers to any of the same objects as the
+     * provided Address object.
+     * @param Address $address
+     * @return boolean
+     */
     public function isMatch(Address $address)
     {
         if (!is_null($address->getBin()) && !is_null($this->bin) && $address->getBin() !== $this->bin) {
@@ -44,10 +79,17 @@ final class Address implements \Serializable
         return true;
     }
 
-    // The serialized form must:
-    //  - Place the bin first
-    //  - Return a prefix matching all entries in a bin with a NULL key
-    //  - Return a prefix matching all entries with a NULL bin
+    /**
+     * Serialize this object, returning a string representing this address.
+     *
+     * The serialized form must:
+     *
+     *  - Place the bin first
+     *  - Return a prefix matching all entries in a bin with a NULL key
+     *  - Return a prefix matching all entries with a NULL bin
+     *
+     * @return string
+     */
     public function serialize()
     {
         if (is_null($this->bin)) {
@@ -62,6 +104,10 @@ final class Address implements \Serializable
         return $length_prefixed_bin . ':' . $this->key;
     }
 
+    /**
+     * Unpack a serialized Address into this object.
+     * @param string $serialized
+     */
     public function unserialize($serialized)
     {
         $entries = explode(':', $serialized, 2);

--- a/src/DatabaseL2.php
+++ b/src/DatabaseL2.php
@@ -200,8 +200,8 @@ class DatabaseL2 extends L2
     }
 
     /**
-   * @codeCoverageIgnore
-   */
+     * @codeCoverageIgnore
+     */
     public function debugDumpState()
     {
         echo PHP_EOL . PHP_EOL . 'Events:' . PHP_EOL;

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -23,11 +23,19 @@ final class Entry
         $this->tags = $tags;
     }
 
+    /**
+     * Return the Address for this entry.
+     * @return Address
+     */
     public function getAddress()
     {
         return $this->address;
     }
 
+    /**
+     * Return the time-to-live for this entry.
+     * @return integer
+     */
     public function getTTL()
     {
         if (is_null($this->expiration)) {

--- a/src/LX.php
+++ b/src/LX.php
@@ -2,12 +2,20 @@
 
 namespace LCache;
 
+/**
+ * Base class for the various cache classes.
+ */
 abstract class LX
 {
     abstract public function getEntry(Address $address);
     abstract public function getHits();
     abstract public function getMisses();
 
+    /**
+     * Fetch a value from the cache.
+     * @param Address $address
+     * @return string|null
+     */
     public function get(Address $address)
     {
         $entry = $this->getEntry($address);
@@ -17,6 +25,11 @@ abstract class LX
         return $entry->value;
     }
 
+    /**
+     * Determine whether or not the specified Address exists in the cache.
+     * @param Address $address
+     * @return type
+     */
     public function exists(Address $address)
     {
         $value = $this->get($address);

--- a/src/LX.php
+++ b/src/LX.php
@@ -28,7 +28,7 @@ abstract class LX
     /**
      * Determine whether or not the specified Address exists in the cache.
      * @param Address $address
-     * @return type
+     * @return boolean
      */
     public function exists(Address $address)
     {


### PR DESCRIPTION
This PR is a simple PoC on adding some API documentation to lcache.  This version uses a very simple / small project that emits a one-page markdown file that can be read directly from GitHub, or easily integrated into a ReadTheDocs site.  An example of what it looks like can be seen here:

https://github.com/lcache/lcache/blob/72e77ad0eb09256f96d9f154cdbf5cedf43fc7ae/docs/api.md

The markdown parser is not perfect; I needed to insert <br>s into the list in the `serialize()` method to make it format correctly, for example.  However, it seems to work pretty well, and I think it adds some value.

As a possible alternative, Simi, the Symfony API document generator, is really easy to run and produces stellar output.  Example here:

http://api.symfony.com/3.0/index.html

The issue with Simi, though, is that it dumps out a whole pile of html pages; we'd need to set up gh-pages, or something like that to host it. Seems like overkill for this small project.

Finally, anyone have any idea why phpunit is segfaulting on Travis?  The tests run just fine for me locally.
