### PR TITLE
Add a static factory for Integrated LCache object.

### DIFF
--- a/src/Integrated.php
+++ b/src/Integrated.php
@@ -20,7 +20,7 @@ final class Integrated
         // Use the Null L1 cache for the CLI.
         $l1 = new NullL1();
         if (php_sapi_name() !== 'cli') {
-          $l1 = new APCuL1();
+            $l1 = new APCuL1();
         }
         $l2 = new DatabaseL2($dbh, $table_prefix, $log_locally);
 

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -489,6 +489,17 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->assertFalse($pool->exists($myaddr));
     }
 
+    public function testExistsIntegratedWithStaticFactory()
+    {
+        $this->createSchema();
+        $pool = Integrated::create($this->dbh);
+        $myaddr = new Address('mybin', 'mykey');
+        $pool->set($myaddr, 'myvalue');
+        $this->assertTrue($pool->exists($myaddr));
+        $pool->delete($myaddr);
+        $this->assertFalse($pool->exists($myaddr));
+    }
+
     public function testDatabaseL2Prefix()
     {
         $this->createSchema('myprefix_');


### PR DESCRIPTION
This PR provides a static factory method for the Integrated LCache object:

```
$integrated = \LCache\Integrated::create($dbh);
```

This allows canonical clients to reference only Address and Integrated classes.

This PR does not test the new `LCache:: setOverheadThreshhold()` method, but I could add a test to pick that up to keep us at 100% coverage if this general concept (reducing required API touch-points for canonical clients) is desired.
