### PR TITLE
StaticL2: Clone before unserializing

### DIFF
--- a/src/StaticL2.php
+++ b/src/StaticL2.php
@@ -55,7 +55,7 @@ class StaticL2 extends L2
                 } elseif (!is_null($entry->expiration) && $entry->expiration < $_SERVER['REQUEST_TIME']) {
                     $last_matching_entry = null;
                 } else {
-                    $last_matching_entry = $entry;
+                    $last_matching_entry = clone $entry;
                 }
             }
         }

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -137,6 +137,17 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->assertNull($l2->get($myaddr));
     }
 
+    public function testStaticL2Reread()
+    {
+        $l2 = new StaticL2();
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+    }
+
     public function testNewPoolSynchronization()
     {
         $central = new StaticL2();


### PR DESCRIPTION
This fixes issues uncovered by unserializing items that have previously been unserialized in StaticL2.