### PR TITLE
Use write-around instead of write-through

### DIFF
--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -34,6 +34,17 @@ class APCuL1 extends L1
         return 0;
     }
 
+    public function incrementOverhead(Address $address)
+    {
+        $apcu_key = $this->getLocalKey($address);
+        apcu_inc($apcu_key . ':overhead', 1, $overhead_success);
+        if (!$overhead_success) {
+            // @codeCoverageIgnoreStart
+            apcu_store($apcu_key . ':overhead', 1);
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
     public function setWithExpiration($event_id, Address $address, $value, $created, $expiration = null)
     {
         $apcu_key = $this->getLocalKey($address);
@@ -55,12 +66,7 @@ class APCuL1 extends L1
 
         // If not setting a negative cache entry, increment the key's overhead.
         if (!is_null($value)) {
-            apcu_inc($apcu_key . ':overhead', 1, $overhead_success);
-            if (!$overhead_success) {
-                // @codeCoverageIgnoreStart
-                apcu_store($apcu_key . ':overhead', 1);
-                // @codeCoverageIgnoreEnd
-            }
+            $this->incrementOverhead($address);
         }
 
         return $success;

--- a/src/Integrated.php
+++ b/src/Integrated.php
@@ -55,7 +55,7 @@ final class Integrated
 
         $event_id = $this->l2->set($this->l1->getPool(), $address, $value, $expiration, $tags);
         if (!is_null($event_id)) {
-            $this->l1->set($event_id, $address, $value, $expiration);
+            $this->l1->incrementOverhead($address);
         }
         return $event_id;
     }

--- a/src/L1.php
+++ b/src/L1.php
@@ -31,6 +31,8 @@ abstract class L1 extends LX
         return $this->setWithExpiration($event_id, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);
     }
 
+    abstract public function incrementOverhead(Address $address);
+
     abstract public function isNegativeCache(Address $address);
     abstract public function getKeyOverhead(Address $address);
     abstract public function setWithExpiration($event_id, Address $address, $value, $created, $expiration = null);

--- a/src/StaticL1.php
+++ b/src/StaticL1.php
@@ -32,17 +32,23 @@ class StaticL1 extends L1
         return 0;
     }
 
+    public function incrementOverhead(Address $address)
+    {
+        $local_key = $address->serialize();
+        if (isset($this->key_overhead[$local_key])) {
+            $this->key_overhead[$local_key]++;
+        } else {
+            $this->key_overhead[$local_key] = 1;
+        }
+    }
+
     public function setWithExpiration($event_id, Address $address, $value, $created, $expiration = null)
     {
         $local_key = $address->serialize();
 
         // If not setting a negative cache entry, increment the key's overhead.
         if (!is_null($value)) {
-            if (isset($this->key_overhead[$local_key])) {
-                $this->key_overhead[$local_key]++;
-            } else {
-                $this->key_overhead[$local_key] = 1;
-            }
+            $this->incrementOverhead($address);
         }
 
         // Don't overwrite local entries that are even newer.

--- a/src/StaticL2.php
+++ b/src/StaticL2.php
@@ -87,7 +87,9 @@ class StaticL2 extends L2
         if (!$value_is_serialized) {
             $value = serialize($value);
         }
-        $this->events[$this->current_event_id] = new Entry($this->current_event_id, $pool, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);
+
+        $entry = new Entry($this->current_event_id, $pool, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);
+        $this->events[$this->current_event_id] = $entry;
 
         // Clear existing tags linked to the item. This is much more
         // efficient with database-style indexes.
@@ -160,7 +162,8 @@ class StaticL2 extends L2
                         // Delete the L1 entry, if any, when we fail to unserialize.
                         $l1->delete($event->event_id, $event->getAddress());
                     } else {
-                        $l1->setWithExpiration($event->event_id, $event->getAddress(), $unserialized_value, $event->created, $event->expiration);
+                        //$l1->setWithExpiration($event->event_id, $event->getAddress(), $unserialized_value, $event->created, $event->expiration);
+                        $l1->delete($event->event_id, $event->getAddress());
                     }
                 }
                 $applied++;


### PR DESCRIPTION
This branch alters the cache behavior to write-around (a.k.a. "no-write allocate"), causing L1 to only populate on cache hits to L2. This avoids filling L1 with unnecessary content that was written once, never to be used again.

This requires the following general changes:

 * Setting a key/value in the `Integrated` cache deletes the value from L1.
 * Synchronizing only deletes entries in L1. DatabaseL2 no longer pulls the values from the database or attempts to unserialize them.
 * Overhead tracking had to be separated from setting L1 values, as setting a value no longer causes an L1 write.

This is not ready to merge, as we may optimize the L1 instead.