### PR TITLE
DatabaseL2: Return rows deleted during GC. Clean up PDO syntax.

### DIFF
--- a/src/DatabaseL2.php
+++ b/src/DatabaseL2.php
@@ -99,10 +99,11 @@ class DatabaseL2 extends L2
             }
             // @codeCoverageIgnoreEnd
             $sth->execute();
+            return $sth->rowCount();
         } catch (\PDOException $e) {
             $this->logSchemaIssueOrRethrow('Failed to collect garbage', $e);
-            return false;
         }
+        return false;
     }
 
     protected function queueDeletion(Address $address)
@@ -251,8 +252,8 @@ class DatabaseL2 extends L2
         if ($address->isEntireBin() || $address->isEntireCache()) {
             $pattern = $address->serialize() . '%';
             $sth = $this->dbh->prepare('DELETE FROM ' . $this->prefixTable('lcache_events') .' WHERE "event_id" < :new_event_id AND "address" LIKE :pattern');
-            $sth->bindValue('new_event_id', $event_id, \PDO::PARAM_INT);
-            $sth->bindValue('pattern', $pattern, \PDO::PARAM_STR);
+            $sth->bindValue(':new_event_id', $event_id, \PDO::PARAM_INT);
+            $sth->bindValue(':pattern', $pattern, \PDO::PARAM_STR);
             $sth->execute();
         } else {
             if (is_null($this->event_id_low_water)) {

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -790,6 +790,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->assertEquals($_SERVER['REQUEST_TIME'] + 1, $l1->getEntry($myaddr)->expiration);
     }
 
+    public function testDatabaseL2BatchDeletion()
+    {
+        $this->createSchema();
+        $l2 = new DatabaseL2($this->dbh);
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+
+        $mybin = new Address('mybin', null);
+        $l2->delete('mypool', $mybin);
+
+        $this->assertNull($l2->get($myaddr));
+    }
+
     /**
     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
     */


### PR DESCRIPTION
- Return false under all failed circumstances for GC.
- Return number of rows removed on GC success.
- Use colon-prefixed strings for bindValue. Added a test to verify malfunction, but the existing code apparently worked. Oh well; at least we get another test.