### PR TITLE
Move L1 pool name generation out of APCuL1

### DIFF
--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -18,15 +18,9 @@ class APCuL1 extends L1
 
     public function __construct($pool = null)
     {
-        if (!is_null($pool)) {
-            $this->pool = $pool;
-        } elseif (isset($_SERVER['SERVER_ADDR']) && isset($_SERVER['SERVER_PORT'])) {
-            $this->pool = $_SERVER['SERVER_ADDR'] . ':' . $_SERVER['SERVER_PORT'];
-        } else {
-            $this->pool = $this->generateUniqueID();
-        }
+        parent::__construct($pool);
 
-        // Using a designated variables to speed-up key generation on runtime.
+        // Using designated variables to speed up key generation during runtime.
         $this->localKeyPrefix = 'lcache' . $this->pool . ':';
         $this->statusKeyHits = 'lcache_status:' . $this->pool . ':hits';
         $this->statusKeyMisses = 'lcache_status:' . $this->pool . ':misses';

--- a/src/L1.php
+++ b/src/L1.php
@@ -6,16 +6,21 @@ abstract class L1 extends LX
 {
     protected $pool;
 
-    public function __construct()
+    public function __construct($pool = null)
     {
-        if (!isset($this->pool)) {
+        if (!is_null($pool)) {
+            $this->pool = $pool;
+        } elseif (isset($_SERVER['SERVER_ADDR']) && isset($_SERVER['SERVER_PORT'])) {
+            $this->pool = $_SERVER['SERVER_ADDR'] . '-' . $_SERVER['SERVER_PORT'];
+        } else {
             $this->pool = $this->generateUniqueID();
         }
     }
 
     protected function generateUniqueID()
     {
-        return uniqid('', true) . ':' . mt_rand();
+        // @TODO: Replace with a persistent but machine-local (and unique) method.
+        return uniqid('', true) . '-' . mt_rand();
     }
 
     abstract public function getLastAppliedEventID();

--- a/src/StaticL1.php
+++ b/src/StaticL1.php
@@ -12,15 +12,13 @@ class StaticL1 extends L1
 
     public function __construct($pool = null)
     {
-        if (!is_null($pool)) {
-            $this->pool = $pool;
-        }
+        parent::__construct($pool);
+
         $this->hits = 0;
         $this->misses = 0;
         $this->key_overhead = [];
         $this->storage = array();
         $this->last_applied_event_id = null;
-        parent::__construct();
     }
 
     public function getKeyOverhead(Address $address)

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -519,7 +519,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $_SERVER['SERVER_ADDR'] = 'localhost';
         $_SERVER['SERVER_PORT'] = '80';
         $l1 = new APCuL1();
-        $this->assertEquals('localhost:80', $l1->getPool());
+        $this->assertEquals('localhost-80', $l1->getPool());
     }
 
     protected function performL1AntirollbackTest($l1)


### PR DESCRIPTION
In preparation for SQLiteL1, move L1 pool auto-naming up to the L1 abstract class. Also, generate pool names that are more likely to be filename-friendly (so SQLite can name its DB after the pools).