### PR TITLE
Only set the negative cache on high overhead. Tighten event ID ordering.

### DIFF
--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -50,9 +50,9 @@ class APCuL1 extends L1
     {
         $apcu_key = $this->getLocalKey($address);
 
-        // Don't overwrite local entries that are even newer.
+        // Don't overwrite local entries that are even newer or the same age.
         $entry = apcu_fetch($apcu_key);
-        if ($entry !== false && $entry->event_id > $event_id) {
+        if ($entry !== false && $entry->event_id >= $event_id) {
             return true;
         }
         $entry = new Entry($event_id, $this->pool, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);

--- a/src/Integrated.php
+++ b/src/Integrated.php
@@ -37,18 +37,16 @@ final class Integrated
                     return null;
                 }
 
-                // Otherwise, delete the item in L2
-                // and create a local negative cache entry.
+                // Otherwise, delete the item in L2.
                 $event_id = $this->l2->delete($this->l1->getPool(), $address);
-                if (!is_null($event_id)) {
-                    $this->l1->set($event_id, $address, $value, $expiration);
-                }
 
-                // Retain this negative cache item for a number of minutes
-                // equivalent to the number of excessive sets over the
-                // threshold, plus one minute.
-                $expiration = $_SERVER['REQUEST_TIME'] + ($excess + 1) * 60;
-                $this->l1->setWithExpiration($event_id, $address, null, $_SERVER['REQUEST_TIME'], $expiration);
+                // If the L2 deletion succeeded, retain a negative cache item
+                // in L1 for a number of minutes equivalent to the number of
+                // excessive sets over the threshold, plus one minute.
+                if (!is_null($event_id)) {
+                    $expiration = $_SERVER['REQUEST_TIME'] + ($excess + 1) * 60;
+                    $this->l1->setWithExpiration($event_id, $address, null, $_SERVER['REQUEST_TIME'], $expiration);
+                }
                 return $event_id;
             }
         }

--- a/src/StaticL1.php
+++ b/src/StaticL1.php
@@ -43,8 +43,8 @@ class StaticL1 extends L1
             }
         }
 
-        // Don't overwrite local entries that are even newer.
-        if (isset($this->storage[$local_key]) && $this->storage[$local_key]->event_id > $event_id) {
+        // Don't overwrite local entries that are even newer or the same age.
+        if (isset($this->storage[$local_key]) && $this->storage[$local_key]->event_id >= $event_id) {
             return true;
         }
         $this->storage[$local_key] = new Entry($event_id, $this->getPool(), $address, $value, $created, $expiration);


### PR DESCRIPTION
Fixes #47.