### PR TITLE
Factored-out the state management in designated classes.

### DIFF
--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -7,15 +7,12 @@ class APCuL1 extends L1
     /** @var string */
     private $localKeyPrefix;
 
-    public function __construct($pool = null)
+    public function __construct($pool, StateL1Interface $state)
     {
-        parent::__construct($pool);
-
-        // TODO: Consifer injecting this.
-        $this->state = new StateL1APCu($this->pool);
+        parent::__construct($pool, $state);
 
         // Using designated variables to speed up key generation during runtime.
-        $this->localKeyPrefix = 'lcache:' . $this->pool . ':';
+        $this->localKeyPrefix = 'lcache:' . $pool . ':';
     }
 
     protected function getLocalKey($address)

--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -26,9 +26,10 @@ class APCuL1 extends L1
         // decrementing the overhead by existing hits when an item is set. This
         // would make hits cheaper but writes more expensive.
 
+        $success = null;
         $apcu_key = $this->getLocalKey($address);
         $overhead = apcu_fetch($apcu_key . ':overhead', $success);
-        if ($success) {
+        if ($success === true) {
             return $overhead;
         }
         return 0;
@@ -55,9 +56,10 @@ class APCuL1 extends L1
 
         // If not setting a negative cache entry, increment the key's overhead.
         if (!is_null($value)) {
+            $overhead_success = null;
             $apcu_key_overhead = $apcu_key . ':overhead';
             apcu_inc($apcu_key_overhead, 1, $overhead_success);
-            if (!$overhead_success) {
+            if ($overhead_success === false) {
                 // @codeCoverageIgnoreStart
                 apcu_store($apcu_key_overhead, 1);
                 // @codeCoverageIgnoreEnd
@@ -69,9 +71,10 @@ class APCuL1 extends L1
 
     public function isNegativeCache(Address $address)
     {
+        $success = null;
         $apcu_key = $this->getLocalKey($address);
         $entry = apcu_fetch($apcu_key, $success);
-        return ($success && is_null($entry->value));
+        return ($success === true && is_null($entry->value));
     }
 
     public function getEntry(Address $address)
@@ -80,16 +83,18 @@ class APCuL1 extends L1
         $apcu_key_overhead = $apcu_key . ':overhead';
 
         // Decrement the key's overhead.
+        $overhead_success = null;
         apcu_dec($apcu_key_overhead, 1, $overhead_success);
-        if (!$overhead_success) {
+        if ($overhead_success === false) {
             // @codeCoverageIgnoreStart
             apcu_store($apcu_key_overhead, -1);
             // @codeCoverageIgnoreEnd
         }
 
+        $success = null;
         $entry = apcu_fetch($apcu_key, $success);
         // Handle failed reads.
-        if (!$success) {
+        if ($success === false) {
             $this->recordMiss();
             return null;
         }

--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -29,7 +29,7 @@ class APCuL1 extends L1
         $success = null;
         $apcu_key = $this->getLocalKey($address);
         $overhead = apcu_fetch($apcu_key . ':overhead', $success);
-        if ($success === true) {
+        if (true === $success) {
             return $overhead;
         }
         return 0;
@@ -59,7 +59,7 @@ class APCuL1 extends L1
             $overhead_success = null;
             $apcu_key_overhead = $apcu_key . ':overhead';
             apcu_inc($apcu_key_overhead, 1, $overhead_success);
-            if ($overhead_success === false) {
+            if (false === $overhead_success) {
                 // @codeCoverageIgnoreStart
                 apcu_store($apcu_key_overhead, 1);
                 // @codeCoverageIgnoreEnd
@@ -74,7 +74,7 @@ class APCuL1 extends L1
         $success = null;
         $apcu_key = $this->getLocalKey($address);
         $entry = apcu_fetch($apcu_key, $success);
-        return ($success === true && is_null($entry->value));
+        return (true === $success && is_null($entry->value));
     }
 
     public function getEntry(Address $address)
@@ -85,7 +85,7 @@ class APCuL1 extends L1
         // Decrement the key's overhead.
         $overhead_success = null;
         apcu_dec($apcu_key_overhead, 1, $overhead_success);
-        if ($overhead_success === false) {
+        if (false === $overhead_success) {
             // @codeCoverageIgnoreStart
             apcu_store($apcu_key_overhead, -1);
             // @codeCoverageIgnoreEnd
@@ -94,7 +94,7 @@ class APCuL1 extends L1
         $success = null;
         $entry = apcu_fetch($apcu_key, $success);
         // Handle failed reads.
-        if ($success === false) {
+        if (false === $success) {
             $this->recordMiss();
             return null;
         }

--- a/src/APCuL1.php
+++ b/src/APCuL1.php
@@ -11,10 +11,8 @@ class APCuL1 extends L1
     {
         parent::__construct($pool);
 
-        // TODO: consifer injecting this...
-        if (!($this->state instanceof StateL1APCu)) {
-            $this->state = new StateL1APCu($this->pool);
-        }
+        // TODO: Consifer injecting this.
+        $this->state = new StateL1APCu($this->pool);
 
         // Using designated variables to speed up key generation during runtime.
         $this->localKeyPrefix = 'lcache:' . $this->pool . ':';

--- a/src/Address.php
+++ b/src/Address.php
@@ -121,7 +121,7 @@ final class Address implements \Serializable
         }
 
         // @TODO: Remove check against false for PHP 7+
-        if ($this->key === false || $this->key === '') {
+        if (false === $this->key || '' === $this->key) {
             $this->key = null;
         }
     }

--- a/src/DatabaseL2.php
+++ b/src/DatabaseL2.php
@@ -162,7 +162,7 @@ class DatabaseL2 extends L2
         //$last_matching_entry = $sth->fetchObject('LCacheEntry');
         $last_matching_entry = $sth->fetchObject();
 
-        if ($last_matching_entry === false) {
+        if (false === $last_matching_entry) {
             $this->misses++;
             return null;
         }
@@ -176,7 +176,7 @@ class DatabaseL2 extends L2
         $unserialized_value = @unserialize($last_matching_entry->value);
 
         // If unserialization failed, raise an exception.
-        if ($unserialized_value === false && $last_matching_entry->value !== serialize(false)) {
+        if (false === $unserialized_value && serialize(false) !== $last_matching_entry->value) {
             throw new UnserializationException($address, $last_matching_entry->value);
         }
 
@@ -364,7 +364,7 @@ class DatabaseL2 extends L2
                 return null;
             }
             $last_event = $sth->fetchObject();
-            if ($last_event === false) {
+            if (false === $last_event) {
                 $l1->setLastAppliedEventID(0);
             } else {
                 $l1->setLastAppliedEventID($last_event->event_id);
@@ -391,7 +391,7 @@ class DatabaseL2 extends L2
                 $l1->delete($event->event_id, $address);
             } else {
                 $unserialized_value = @unserialize($event->value);
-                if ($unserialized_value === false && $event->value !== serialize(false)) {
+                if (false === $unserialized_value && serialize(false) !== $event->value) {
                     // Delete the L1 entry, if any, when we fail to unserialize.
                     $l1->delete($event->event_id, $address);
                 } else {

--- a/src/L1.php
+++ b/src/L1.php
@@ -21,10 +21,6 @@ abstract class L1 extends LX
 
         if (!is_null($state)) {
             $this->state = $state;
-        } elseif (function_exists('apcu_fetch')) {
-            $this->state = new StateL1APCu($this->pool);
-        } else {
-            $this->state = new StateL1Static();
         }
     }
 

--- a/src/L1.php
+++ b/src/L1.php
@@ -9,19 +9,19 @@ abstract class L1 extends LX
     /** @var StateL1Interface */
     protected $state;
 
-    public function __construct($pool = null, StateL1Interface $state = null)
+    /**
+     * Constructor for all the L1 implementations.
+     *
+     * @param string $pool
+     *   Pool ID to group the cache data in.
+     * @param \LCache\StateL1Interface $state
+     *   State manager class. Used to collect hit/miss statistics as well as
+     *   the ID of the last cache mutation event.
+     */
+    public function __construct($pool, StateL1Interface $state)
     {
-        if (!is_null($pool)) {
-            $this->pool = $pool;
-        } elseif (isset($_SERVER['SERVER_ADDR']) && isset($_SERVER['SERVER_PORT'])) {
-            $this->pool = $_SERVER['SERVER_ADDR'] . '-' . $_SERVER['SERVER_PORT'];
-        } else {
-            $this->pool = $this->generateUniqueID();
-        }
-
-        if (!is_null($state)) {
-            $this->state = $state;
-        }
+        $this->pool = $pool;
+        $this->state = $state;
     }
 
     protected function generateUniqueID()

--- a/src/L1.php
+++ b/src/L1.php
@@ -24,12 +24,6 @@ abstract class L1 extends LX
         $this->state = $state;
     }
 
-    protected function generateUniqueID()
-    {
-        // @TODO: Replace with a persistent but machine-local (and unique) method.
-        return uniqid('', true) . '-' . mt_rand();
-    }
-
     public function getLastAppliedEventID()
     {
         return $this->state->getLastAppliedEventID();

--- a/src/L1CacheFactory.php
+++ b/src/L1CacheFactory.php
@@ -63,7 +63,7 @@ class L1CacheFactory
      */
     protected function createNull($pool)
     {
-        return new NullL1($pool, new StateL1Static($pool));
+        return new NullL1($pool, new StateL1Null());
     }
 
     /**
@@ -74,7 +74,7 @@ class L1CacheFactory
      */
     protected function createStatic($pool)
     {
-        return new StaticL1($pool, new StateL1Static($pool));
+        return new StaticL1($pool, new StateL1Static());
     }
 
     /**
@@ -87,7 +87,7 @@ class L1CacheFactory
     {
         $hasApcu = function_exists('apcu_fetch');
         // TODO: Maybe implement StateL1SQLite class instead of NULL one.
-        $state = $hasApcu ? new StateL1APCu($pool) : new StateL1Null($pool);
+        $state = $hasApcu ? new StateL1APCu($pool) : new StateL1Null();
         $cache = new SQLiteL1($pool, $state);
         return $cache;
     }

--- a/src/L1CacheFactory.php
+++ b/src/L1CacheFactory.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * @file
+ * Contains the factory class implementation for the L1 cache drivers.
+ */
+
+namespace LCache;
+
+/**
+ * Class encapsulating the creation logic for all L1 cache driver instances.
+ *
+ * @author ndobromirov
+ */
+class L1CacheFactory
+{
+    /**
+     * L1 cache drivers const
+     *
+     * @todo Change the return value to L1CacheInterface
+     *
+     * @param string $driverName
+     *   Name of the L1 driver implementation to create. One of the DRIVER_*
+     *   class constants.
+     * @param string $customPool
+     *   Pool ID to use for the data separation.
+     *
+     * @return L1
+     *   Concrete instance that confirms to an L1 interface.
+     */
+    public function create($driverName = null, $customPool = null)
+    {
+        // Normalize input.
+        $pool = $this->getPool($customPool);
+        $driver = mb_convert_case($driverName, MB_CASE_LOWER);
+
+        $factoryName = 'create' . $driver;
+        if (!method_exists($this, $factoryName)) {
+            // TODO: Decide on better fallback (if needed).
+            $factoryName = 'createStatic';
+        }
+
+        $l1CacheInstance = call_user_func([$this, $factoryName], $pool);
+        return $l1CacheInstance;
+    }
+
+    /**
+     * Factory method for the L1 APCu driver.
+     *
+     * @param string $pool
+     * @return \LCache\APCuL1
+     */
+    protected function createApcu($pool)
+    {
+        return new APCuL1($pool, new StateL1APCu($pool));
+    }
+
+    /**
+     * Factory method for the L1 NULL driver.
+     *
+     * @param string $pool
+     * @return \LCache\NullL1
+     */
+    protected function createNull($pool)
+    {
+        return new NullL1($pool, new StateL1Static($pool));
+    }
+
+    /**
+     * Factory method for the L1 static driver.
+     *
+     * @param string $pool
+     * @return \LCache\StaticL1
+     */
+    protected function createStatic($pool)
+    {
+        return new StaticL1($pool, new StateL1Static($pool));
+    }
+
+    /**
+     * Factory method for the L1 static driver.
+     *
+     * @param string $pool
+     * @return \LCache\SQLiteL1
+     */
+    protected function createSqlite($pool)
+    {
+        $hasApcu = function_exists('apcu_fetch');
+        // TODO: Maybe implement StateL1SQLite class instead of NULL one.
+        $state = $hasApcu ? new StateL1APCu($pool) : new StateL1Null($pool);
+        $cache = new SQLiteL1($pool, $state);
+        return $cache;
+    }
+
+    /**
+     * Pool generator utility.
+     *
+     * @param string $pool
+     *   Custom pool to use. Defaults to NULL. If the  default is uesed, it will
+     *   atempt to generate a pool value for use.
+     *
+     * @return string
+     *   Pool value based on input and/or environment variables / state.
+     */
+    protected function getPool($pool = null)
+    {
+        $result = null;
+        if (!is_null($pool)) {
+            $result = (string) $pool;
+        } elseif (isset($_SERVER['SERVER_ADDR']) && isset($_SERVER['SERVER_PORT'])) {
+            $result = $_SERVER['SERVER_ADDR'] . '-' . $_SERVER['SERVER_PORT'];
+        } else {
+            $result = $this->generateUniqueID();
+        }
+        return $result;
+    }
+
+    /**
+     * Pool generation utility.
+     *
+     * @see L1CacheFactory::getPool()
+     *
+     * @return string
+     */
+    protected function generateUniqueID()
+    {
+        // @TODO: Replace with a persistent but machine-local (and unique) method.
+        return uniqid('', true) . '-' . mt_rand();
+    }
+}

--- a/src/L1CacheFactory.php
+++ b/src/L1CacheFactory.php
@@ -104,7 +104,6 @@ class L1CacheFactory
      */
     protected function getPool($pool = null)
     {
-        $result = null;
         if (!is_null($pool)) {
             $result = (string) $pool;
         } elseif (isset($_SERVER['SERVER_ADDR']) && isset($_SERVER['SERVER_PORT'])) {

--- a/src/NullL1.php
+++ b/src/NullL1.php
@@ -9,11 +9,4 @@ class NullL1 extends StaticL1
         // Store nothing; always succeed.
         return true;
     }
-
-    public function getLastAppliedEventID()
-    {
-        // Because we store nothing locally, behave as if all events
-        // are applied.
-        return PHP_INT_MAX;
-    }
 }

--- a/src/SQLiteL1.php
+++ b/src/SQLiteL1.php
@@ -42,13 +42,10 @@ class SQLiteL1 extends L1
         return $dbh;
     }
 
-    public function __construct($pool = null)
+    public function __construct($pool, StateL1Interface $state)
     {
-        parent::__construct($pool);
-        $this->dbh = self::getDatabaseHandle($this->pool);
-
-        // TODO: Sniff-out APCu presence and use sqlite or null implementation.
-        $this->state = new StateL1APCu($this->pool);
+        parent::__construct($pool, $state);
+        $this->dbh = self::getDatabaseHandle($pool);
     }
 
     protected function pruneExpiredEntries()

--- a/src/SQLiteL1.php
+++ b/src/SQLiteL1.php
@@ -82,7 +82,7 @@ class SQLiteL1 extends L1
         $sth->execute();
         $result = $sth->fetchObject();
 
-        if ($result === false) {
+        if (false === $result) {
             return 0;
         }
 
@@ -175,7 +175,7 @@ class SQLiteL1 extends L1
         // do this to simultaneously track useful overhead data but not unnecessarily
         // record reads after they massively outweigh writes for an address.
         // @TODO: Make this adapt to overhead thresholds.
-        if ($entry === false || $entry->reads < 10 * $entry->writes || $entry->reads < 10) {
+        if (false === $entry || $entry->reads < 10 * $entry->writes || $entry->reads < 10) {
             $sth = $this->dbh->prepare('UPDATE entries SET "reads" = "reads" + 1 WHERE "address" = :address');
             $sth->bindValue(':address', $address->serialize(), \PDO::PARAM_STR);
             $sth->execute();
@@ -188,7 +188,7 @@ class SQLiteL1 extends L1
             }
         }
 
-        if ($entry === false) {
+        if (false === $entry) {
             $this->recordMiss();
             return null;
         }

--- a/src/StateL1APCu.php
+++ b/src/StateL1APCu.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace LCache;
+
+/**
+ * Description of StateL1APCu
+ *
+ * @author ndobromirov
+ */
+class StateL1APCu implements StateL1Interface
+{
+    private $pool;
+
+    /** @var string */
+    private $statusKeyHits;
+
+    /** @var string */
+    private $statusKeyMisses;
+
+    /** @var string */
+    private $statusKeyLastAppliedEventId;
+
+    public function __construct($pool)
+    {
+        $this->pool = $pool;
+
+        // Using designated variables to speed up key generation during runtime.
+        $this->statusKeyHits = 'lcache_status:' . $this->pool . ':hits';
+        $this->statusKeyMisses = 'lcache_status:' . $this->pool . ':misses';
+        $this->statusKeyLastAppliedEventId = 'lcache_status:' . $this->pool . ':last_applied_event_id';
+    }
+
+    public function recordHit()
+    {
+        apcu_inc($this->statusKeyHits, 1, $success);
+        if (!$success) {
+            // @TODO: Remove this fallback when we drop APCu 4.x support.
+            // @codeCoverageIgnoreStart
+            // Ignore coverage because (1) it's tested with other code and
+            // (2) APCu 5.x does not use it.
+            apcu_store($this->statusKeyHits, 1);
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    public function recordMiss()
+    {
+        apcu_inc($this->statusKeyMisses, 1, $success);
+        if (!$success) {
+            // @TODO: Remove this fallback when we drop APCu 4.x support.
+            // @codeCoverageIgnoreStart
+            // Ignore coverage because (1) it's tested with other code and
+            // (2) APCu 5.x does not use it.
+            apcu_store($this->statusKeyMisses, 1);
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    public function getHits()
+    {
+        $value = apcu_fetch($this->statusKeyHits);
+        return $value ? $value : 0;
+    }
+
+    public function getMisses()
+    {
+        $value = apcu_fetch($this->statusKeyMisses);
+        return $value ? $value : 0;
+    }
+
+    public function getLastAppliedEventID()
+    {
+        $value = apcu_fetch($this->statusKeyLastAppliedEventId);
+        if ($value === false) {
+            $value = null;
+        }
+        return $value;
+    }
+
+    public function setLastAppliedEventID($eventId)
+    {
+        return apcu_store($this->statusKeyLastAppliedEventId, $eventId);
+    }
+
+    public function clear()
+    {
+        apcu_store($this->statusKeyHits, 0);
+        apcu_store($this->statusKeyMisses, 0);
+        // TODO: Decide on how to handle the last applied event state on clear?
+    }
+}

--- a/src/StateL1APCu.php
+++ b/src/StateL1APCu.php
@@ -106,7 +106,7 @@ class StateL1APCu implements StateL1Interface
     public function getLastAppliedEventID()
     {
         $value = apcu_fetch($this->statusKeyLastAppliedEventId);
-        if ($value === false) {
+        if (false === $value) {
             $value = null;
         }
         return $value;

--- a/src/StateL1Interface.php
+++ b/src/StateL1Interface.php
@@ -1,30 +1,70 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * @file
+ * L1 state manager interface.
  */
 
 namespace LCache;
 
 /**
+ * Interface for the state manager drivers used in L1 driver implementations.
  *
  * @author ndobromirov
  */
 interface StateL1Interface
 {
+    /**
+     * Records a cache-hit event in the driver.
+     */
     public function recordHit();
 
+    /**
+     * Accessor for the aggregated value of cache-hit events on the driver.
+     *
+     * @return int
+     *   The cache-hits count.
+     */
     public function getHits();
 
+    /**
+     * Records a cache-miss event in the driver.
+     */
     public function recordMiss();
 
+    /**
+     * Accessor for the aggregated value of cache-miss events on the driver.
+     *
+     * @return int
+     *   The cache-misses count.
+     */
     public function getMisses();
 
-    public function getLastAppliedEventID();
-
+    /**
+     * Stores the last applied cache mutation event id in the L1 cache.
+     *
+     * This is needed, so on consecuitive requests, we should apply all events
+     * newer than this one.
+     *
+     * @param int $eventId
+     *   Event ID to store for future reference.
+     */
     public function setLastAppliedEventID($eventId);
 
+    /**
+     * Accessor for the last applied event id on the L1 driver.
+     *
+     * @see StateL1Interface::setLastAppliedEventID($eventId)
+     *
+     * @return int
+     *   The EventID stored or NULL.
+     */
+    public function getLastAppliedEventID();
+
+    /**
+     * Clears the collected statistical data.
+     *
+     * @todo: Should the last applied event be cleared as well?
+     */
     public function clear();
 }

--- a/src/StateL1Interface.php
+++ b/src/StateL1Interface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace LCache;
+
+/**
+ *
+ * @author ndobromirov
+ */
+interface StateL1Interface
+{
+    public function recordHit();
+
+    public function getHits();
+
+    public function recordMiss();
+
+    public function getMisses();
+
+    public function getLastAppliedEventID();
+
+    public function setLastAppliedEventID($eventId);
+
+    public function clear();
+}

--- a/src/StateL1Interface.php
+++ b/src/StateL1Interface.php
@@ -10,6 +10,12 @@ namespace LCache;
 /**
  * Interface for the state manager drivers used in L1 driver implementations.
  *
+ * This interface is separated from L1 drivers, due to the need to separate L1
+ * storage implementations from L1 statistics storage. It was proven that L1
+ * SQLite driver implementation is much slower, unless APCu is used for the
+ * events data tracking. This pushed the need to separate statistics storage
+ * from the main storage of L1 data and to allow free combinations between them.
+ *
  * @author ndobromirov
  */
 interface StateL1Interface

--- a/src/StateL1Null.php
+++ b/src/StateL1Null.php
@@ -12,14 +12,11 @@ namespace LCache;
  *
  * @author ndobromirov
  */
-class StateL1Null implements StateL1Interface
+class StateL1Null extends StateL1Static implements StateL1Interface
 {
-    /**
-     * {inheritdoc}
-     */
-    public function clear()
+    public function __construct()
     {
-        // Nothing to do here.
+        parent::__construct();
     }
 
     /**
@@ -33,23 +30,7 @@ class StateL1Null implements StateL1Interface
     /**
      * {inheritdoc}
      */
-    public function getMisses()
-    {
-        return 0;
-    }
-
-    /**
-     * {inheritdoc}
-     */
     public function recordHit()
-    {
-        return false;
-    }
-
-    /**
-     * {inheritdoc}
-     */
-    public function recordMiss()
     {
         return false;
     }

--- a/src/StateL1Null.php
+++ b/src/StateL1Null.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * Null implementation for L1 state holder.
+ */
+
+namespace LCache;
+
+/**
+ * Fake/Stub state manager class.
+ *
+ * @author ndobromirov
+ */
+class StateL1Null implements StateL1Interface
+{
+    /**
+     * {inheritdoc}
+     */
+    public function clear()
+    {
+        // Nothing to do here.
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function getHits()
+    {
+        return 0;
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function getMisses()
+    {
+        return 0;
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function recordHit()
+    {
+        return false;
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function recordMiss()
+    {
+        return false;
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function getLastAppliedEventID()
+    {
+        // TODO: Decide on this.
+        // Current assumtion is that all events were applied already.
+        return PHP_INT_MAX;
+    }
+
+    /**
+     * {inheritdoc}
+     */
+    public function setLastAppliedEventID($eventId)
+    {
+        // Always success.
+        return true;
+    }
+}

--- a/src/StateL1Null.php
+++ b/src/StateL1Null.php
@@ -40,8 +40,8 @@ class StateL1Null extends StateL1Static implements StateL1Interface
      */
     public function getLastAppliedEventID()
     {
-        // TODO: Decide on this.
-        // Current assumtion is that all events were applied already.
+        // Because we store nothing locally, behave as if all events
+        // are applied.
         return PHP_INT_MAX;
     }
 

--- a/src/StateL1Null.php
+++ b/src/StateL1Null.php
@@ -24,15 +24,8 @@ class StateL1Null extends StateL1Static implements StateL1Interface
      */
     public function getHits()
     {
+        // No cache hits on the null stats.
         return 0;
-    }
-
-    /**
-     * {inheritdoc}
-     */
-    public function recordHit()
-    {
-        return false;
     }
 
     /**
@@ -40,17 +33,8 @@ class StateL1Null extends StateL1Static implements StateL1Interface
      */
     public function getLastAppliedEventID()
     {
-        // Because we store nothing locally, behave as if all events
-        // are applied.
+        // Because we store nothing locally.
+        // Behave as if all events are applied.
         return PHP_INT_MAX;
-    }
-
-    /**
-     * {inheritdoc}
-     */
-    public function setLastAppliedEventID($eventId)
-    {
-        // Always success.
-        return true;
     }
 }

--- a/src/StateL1Static.php
+++ b/src/StateL1Static.php
@@ -1,9 +1,8 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * @file
+ * In-memory implementation of statistics storage for L1 drivers.
  */
 
 namespace LCache;
@@ -15,47 +14,76 @@ namespace LCache;
  */
 class StateL1Static implements StateL1Interface
 {
+    /** @var int Container variable for the cache-hit count. */
     protected $hits;
+
+    /** @var int Container variable for the cache-miss count. */
     protected $misses;
+
+    /** @var int Container variable for the last applied event id value. */
     protected $last_applied_event_id;
 
+    /**
+     * Constructor.
+     */
     public function __construct()
     {
         $this->last_applied_event_id = null;
         $this->clear();
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function recordHit()
     {
         $this->hits++;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function recordMiss()
     {
         $this->misses++;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function getHits()
     {
         return $this->hits;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function getMisses()
     {
         return $this->misses;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function getLastAppliedEventID()
     {
         return $this->last_applied_event_id;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function setLastAppliedEventID($eventId)
     {
         $this->last_applied_event_id = $eventId;
         return true;
     }
 
+    /**
+     * {inheritdoc}
+     */
     public function clear()
     {
         $this->hits = $this->misses = 0;

--- a/src/StateL1Static.php
+++ b/src/StateL1Static.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace LCache;
+
+/**
+ * Description of StateL1Static
+ *
+ * @author ndobromirov
+ */
+class StateL1Static implements StateL1Interface
+{
+    protected $hits;
+    protected $misses;
+    protected $last_applied_event_id;
+
+    public function __construct()
+    {
+        $this->last_applied_event_id = null;
+        $this->clear();
+    }
+
+    public function recordHit()
+    {
+        $this->hits++;
+    }
+
+    public function recordMiss()
+    {
+        $this->misses++;
+    }
+
+    public function getHits()
+    {
+        return $this->hits;
+    }
+
+    public function getMisses()
+    {
+        return $this->misses;
+    }
+
+    public function getLastAppliedEventID()
+    {
+        return $this->last_applied_event_id;
+    }
+
+    public function setLastAppliedEventID($eventId)
+    {
+        $this->last_applied_event_id = $eventId;
+        return true;
+    }
+
+    public function clear()
+    {
+        $this->hits = $this->misses = 0;
+    }
+}

--- a/src/StaticL1.php
+++ b/src/StaticL1.php
@@ -7,9 +7,9 @@ class StaticL1 extends L1
     protected $key_overhead;
     protected $storage;
 
-    public function __construct($pool = null)
+    public function __construct($pool, StateL1Interface $state)
     {
-        parent::__construct($pool, new StateL1Static());
+        parent::__construct($pool, $state);
 
         $this->key_overhead = [];
         $this->storage = array();

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -43,7 +43,8 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->dbh->exec('CREATE INDEX ' . $prefix . 'rewritten_entry ON ' . $prefix . 'lcache_tags ("event_id")');
     }
 
-    public function testL1Factory() {
+    public function testL1Factory()
+    {
         $staticL1 = $this->l1Factory()->create('static');
         $invalidL1 = $this->l1Factory()->create('invalid_cache_driver');
         $this->assertEquals(get_class($staticL1), get_class($invalidL1));

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -15,7 +15,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
      */
     protected function l1Factory()
     {
-        if ($this->_factory === NULL) {
+        if ($this->_factory === null) {
             $this->_factory = new L1CacheFactory();
         }
         return $this->_factory;

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -43,6 +43,12 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->dbh->exec('CREATE INDEX ' . $prefix . 'rewritten_entry ON ' . $prefix . 'lcache_tags ("event_id")');
     }
 
+    public function testL1Factory() {
+        $staticL1 = $this->l1Factory()->create('static');
+        $invalidL1 = $this->l1Factory()->create('invalid_cache_driver');
+        $this->assertEquals(get_class($staticL1), get_class($invalidL1));
+    }
+
     public function testNullL1()
     {
         $event_id = 1;

--- a/tests/LCacheTest.php
+++ b/tests/LCacheTest.php
@@ -8,6 +8,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 {
     protected $dbh = null;
 
+    private $_factory;
+    /**
+     *
+     * @return \LCache\L1CacheFactory
+     */
+    protected function l1Factory()
+    {
+        if ($this->_factory === NULL) {
+            $this->_factory = new L1CacheFactory();
+        }
+        return $this->_factory;
+    }
+
     /**
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
@@ -33,7 +46,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testNullL1()
     {
         $event_id = 1;
-        $cache = new NullL1();
+        $cache = $this->l1Factory()->create('null');
         $myaddr = new Address('mybin', 'mykey');
         $cache->set($event_id++, $myaddr, 'myvalue');
         $entry = $cache->get($myaddr);
@@ -100,25 +113,27 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testStaticL1SetGetDelete()
     {
-        $l1 = new StaticL1();
+
+        $l1 = $this->l1Factory()->create('static');
         $this->performSetGetDeleteTest($l1);
     }
 
     public function testSQLiteL1SetGetDelete()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performSetGetDeleteTest($l1);
     }
 
     public function testAPCuL1SetGetDelete()
     {
-        $l1 = new APCuL1('setGetDelete');
+        $l1 = $this->l1Factory()->create('apcu', 'setGetDelete');
+
         $this->performSetGetDeleteTest($l1);
     }
 
     public function testStaticL1Antirollback()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performL1AntirollbackTest($l1);
     }
 
@@ -139,19 +154,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testSQLiteL1FullDelete()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performL1FullDelete($l1);
     }
 
     public function testAPCuL1FullDelete()
     {
-        $l1 = new APCuL1('setGetDelete');
+        $l1 = $this->l1Factory()->create('apcu', 'setGetDelete');
         $this->performL1FullDelete($l1);
     }
 
     public function testStaticL1FullDelete()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performL1FullDelete($l1);
     }
 
@@ -170,19 +185,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testSQLiteL1Expiration()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performL1Expiration($l1);
     }
 
     public function testAPCuL1Expiration()
     {
-        $l1 = new APCuL1('expiration');
+        $l1 = $this->l1Factory()->create('apcu', 'expiration');
         $this->performL1Expiration($l1);
     }
 
     public function testStaticL1Expiration()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performL1Expiration($l1);
     }
 
@@ -217,7 +232,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testNewPoolSynchronization()
     {
         $central = new StaticL2();
-        $pool1 = new Integrated(new StaticL1(), $central);
+        $pool1 = new Integrated($this->l1Factory()->create('static'), $central);
 
         $myaddr = new Address('mybin', 'mykey');
 
@@ -237,7 +252,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
         // Add a new pool. Sync should return NULL applied changes but should
         // bump the last applied event ID.
-        $pool2 = new Integrated(new StaticL1(), $central);
+        $pool2 = new Integrated($this->l1Factory()->create('static'), $central);
         $applied = $pool2->synchronize();
         $this->assertNull($applied);
         $this->assertEquals($pool1->getLastAppliedEventID(), $pool2->getLastAppliedEventID());
@@ -269,19 +284,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testStaticL1Tombstone()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performTombstoneTest($l1);
     }
 
     public function testAPCuL1Tombstone()
     {
-        $l1 = new APCuL1('testAPCuL1Tombstone');
+        $l1 = $this->l1Factory()->create('apcu', 'testAPCuL1Tombstone');
         $this->performTombstoneTest($l1);
     }
 
     public function testSQLiteL1Tombstone()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performTombstoneTest($l1);
     }
 
@@ -446,13 +461,13 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testSynchronizationStatic()
     {
         $central = new StaticL2();
-        $this->performSynchronizationTest($central, new StaticL1(), new StaticL1());
+        $this->performSynchronizationTest($central, $this->l1Factory()->create('static'), $this->l1Factory()->create('static'));
     }
 
     public function testTaggedSynchronizationStatic()
     {
         $central = new StaticL2();
-        $this->performTaggedSynchronizationTest($central, new StaticL1(), new StaticL1());
+        $this->performTaggedSynchronizationTest($central, $this->l1Factory()->create('static'), $this->l1Factory()->create('static'));
     }
 
     public function testSynchronizationAPCu()
@@ -472,11 +487,23 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
         if ($run_test) {
             $central = new StaticL2();
-            $this->performSynchronizationTest($central, new APCuL1('testSynchronizationAPCu1'), new APCuL1('testSynchronizationAPCu2'));
+            $this->performSynchronizationTest(
+                $central,
+                $this->l1Factory()->create('apcu', 'testSynchronizationAPCu1'),
+                $this->l1Factory()->create('apcu', 'testSynchronizationAPCu2')
+            );
 
             // Because of how APCu only offers full cache clears, we test against a static cache for the other L1.
-            $this->performClearSynchronizationTest($central, new APCuL1('testSynchronizationAPCu1b'), new StaticL1());
-            $this->performClearSynchronizationTest($central, new StaticL1(), new APCuL1('testSynchronizationAPCu1c'));
+            $this->performClearSynchronizationTest(
+                $central,
+                $this->l1Factory()->create('apcu', 'testSynchronizationAPCu1b'),
+                $this->l1Factory()->create('static')
+            );
+            $this->performClearSynchronizationTest(
+                $central,
+                $this->l1Factory()->create('static'),
+                $this->l1Factory()->create('apcu', 'testSynchronizationAPCu1c')
+            );
         } else {
             $this->markTestSkipped('The APCu extension is not installed, enabled (for the CLI), or functional.');
         }
@@ -485,33 +512,61 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testSynchronizationSQLiteL1()
     {
         $central = new StaticL2();
-        $this->performSynchronizationTest($central, new SQLiteL1(), new SQLiteL1());
+        $this->performSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('sqlite'),
+            $this->l1Factory()->create('sqlite')
+        );
 
-        $this->performClearSynchronizationTest($central, new SQLiteL1(), new StaticL1());
-        $this->performClearSynchronizationTest($central, new StaticL1(), new SQLiteL1());
-        $this->performClearSynchronizationTest($central, new SQLiteL1(), new SQLiteL1());
+        $this->performClearSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('sqlite'),
+            $this->l1Factory()->create('static')
+        );
+        $this->performClearSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('static'),
+            $this->l1Factory()->create('sqlite')
+        );
+        $this->performClearSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('sqlite'),
+            $this->l1Factory()->create('sqlite')
+        );
     }
 
     public function testSynchronizationDatabase()
     {
         $this->createSchema();
         $central = new DatabaseL2($this->dbh);
-        $this->performSynchronizationTest($central, new StaticL1('testSynchronizationDatabase1'), new StaticL1('testSynchronizationDatabase2'));
-        $this->performClearSynchronizationTest($central, new StaticL1('testSynchronizationDatabase1a'), new StaticL1('testSynchronizationDatabase2a'));
+        $this->performSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('static', 'testSynchronizationDatabase1'),
+            $this->l1Factory()->create('static', 'testSynchronizationDatabase2')
+        );
+        $this->performClearSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('static', 'testSynchronizationDatabase1a'),
+            $this->l1Factory()->create('static', 'testSynchronizationDatabase2a')
+        );
     }
 
     public function testTaggedSynchronizationDatabase()
     {
         $this->createSchema();
         $central = new DatabaseL2($this->dbh);
-        $this->performTaggedSynchronizationTest($central, new StaticL1('testTaggedSynchronizationDatabase1'), new StaticL1('testTaggedSynchronizationDatabase2'));
+        $this->performTaggedSynchronizationTest(
+            $central,
+            $this->l1Factory()->create('static', 'testTaggedSynchronizationDatabase1'),
+            $this->l1Factory()->create('static', 'testTaggedSynchronizationDatabase2')
+        );
     }
 
     public function testBrokenDatabaseFallback()
     {
         $this->createSchema();
         $l2 = new DatabaseL2($this->dbh, '', true);
-        $l1 = new StaticL1('first');
+        $l1 = $this->l1Factory()->create('static', 'first');
         $pool = new Integrated($l1, $l2);
 
         $myaddr = new Address('mybin', 'mykey');
@@ -535,7 +590,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->assertNull($l2->getAddressesForTag('mytag'));
 
         // Try applying events to an uninitialized L1.
-        $this->assertNull($l2->applyEvents(new StaticL1()));
+        $this->assertNull($l2->applyEvents($this->l1Factory()->create('static')));
 
         // Try garbage collection routines.
         $pool->collectGarbage();
@@ -547,7 +602,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     {
         $this->createSchema();
         $l2 = new DatabaseL2($this->dbh, '', true);
-        $l1 = new StaticL1('first');
+        $l1 = $this->l1Factory()->create('static', 'first');
         $pool = new Integrated($l1, $l2);
         $pool->synchronize();
     }
@@ -580,19 +635,19 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testExistsAPCuL1()
     {
-        $l1 = new APCuL1('first');
+        $l1 = $this->l1Factory()->create('apcu', 'first');
         $this->performExistsTest($l1);
     }
 
     public function testExistsStaticL1()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performExistsTest($l1);
     }
 
     public function testExistsSQLiteL1()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performExistsTest($l1);
     }
 
@@ -600,7 +655,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     {
         $this->createSchema();
         $l2 = new DatabaseL2($this->dbh);
-        $l1 = new APCuL1('first');
+        $l1 = $this->l1Factory()->create('apcu', 'first');
         $pool = new Integrated($l1, $l2);
         $myaddr = new Address('mybin', 'mykey');
         $pool->set($myaddr, 'myvalue');
@@ -621,13 +676,13 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testAPCuL1PoolIDs()
     {
         // Test unique ID generation.
-        $l1 = new APCuL1();
+        $l1 = $this->l1Factory()->create('apcu');
         $this->assertNotNull($l1->getPool());
 
         // Test host-based generation.
         $_SERVER['SERVER_ADDR'] = 'localhost';
         $_SERVER['SERVER_PORT'] = '80';
-        $l1 = new APCuL1();
+        $l1 = $this->l1Factory()->create('apcu');
         $this->assertEquals('localhost-80', $l1->getPool());
     }
 
@@ -646,13 +701,13 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testAPCuL1Antirollback()
     {
-        $l1 = new APCuL1('first');
+        $l1 = $this->l1Factory()->create('apcu', 'first');
         $this->performL1AntirollbackTest($l1);
     }
 
     public function testSQLite1Antirollback()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performL1AntirollbackTest($l1);
     }
 
@@ -671,33 +726,33 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testStaticL1HitMiss()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performL1HitMissTest($l1);
     }
 
     public function testAPCuL1HitMiss()
     {
-        $l1 = new APCuL1('testAPCuL1HitMiss');
+        $l1 = $this->l1Factory()->create('apcu', 'testAPCuL1HitMiss');
         $this->performL1HitMissTest($l1);
     }
 
     public function testSQLiteL1HitMiss()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performL1HitMissTest($l1);
     }
 
     public function testPoolIntegrated()
     {
         $l2 = new StaticL2();
-        $l1 = new APCuL1('first');
+        $l1 = $this->l1Factory()->create('apcu', 'first');
         $pool = new Integrated($l1, $l2);
         $this->assertEquals('first', $pool->getPool());
     }
 
     protected function performFailedUnserializationTest($l2)
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $pool = new Integrated($l1, $l2);
         $myaddr = new Address('mybin', 'mykey');
 
@@ -723,7 +778,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     protected function performCaughtUnserializationOnGetTest($l2)
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $pool = new Integrated($l1, $l2);
         $invalid_object = 'O:10:"HelloWorl":0:{}';
         $myaddr = new Address('mybin', 'performCaughtUnserializationOnGetTest');
@@ -759,7 +814,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     // Callers should expect an UnserializationException.
     protected function performFailedUnserializationOnGetTest($l2)
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $pool = new Integrated($l1, $l2);
         $invalid_object = 'O:10:"HelloWorl":0:{}';
         $myaddr = new Address('mybin', 'performFailedUnserializationOnGetTest');
@@ -788,7 +843,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function performGarbageCollectionTest($l2)
     {
-        $pool = new Integrated(new StaticL1(), $l2);
+        $pool = new Integrated($this->l1Factory()->create('static'), $l2);
         $myaddr = new Address('mybin', 'mykey');
         $this->assertEquals(0, $l2->countGarbage());
         $pool->set($myaddr, 'myvalue', -1);
@@ -810,7 +865,7 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
         $this->performGarbageCollectionTest($l2);
 
         // Test item limits.
-        $pool = new Integrated(new StaticL1(), $l2);
+        $pool = new Integrated($this->l1Factory()->create('static'), $l2);
         $myaddr2 = new Address('mybin', 'mykey2');
         $myaddr3 = new Address('mybin', 'mykey3');
         $pool->collectGarbage();
@@ -844,17 +899,17 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testStaticL1Counters()
     {
-        $this->performHitSetCounterTest(new StaticL1());
+        $this->performHitSetCounterTest($this->l1Factory()->create('static'));
     }
 
     public function testAPCuL1Counters()
     {
-        $this->performHitSetCounterTest(new APCuL1('counters'));
+        $this->performHitSetCounterTest($this->l1Factory()->create('apcu', 'counters'));
     }
 
     public function testSQLiteL1Counters()
     {
-        $this->performHitSetCounterTest(new SQLiteL1());
+        $this->performHitSetCounterTest($this->l1Factory()->create('sqlite'));
     }
 
     protected function performExcessiveOverheadSkippingTest($l1)
@@ -895,34 +950,34 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
 
     public function testStaticL1ExcessiveOverheadSkipping()
     {
-        $this->performExcessiveOverheadSkippingTest(new StaticL1());
+        $this->performExcessiveOverheadSkippingTest($this->l1Factory()->create('static'));
     }
 
     public function testAPCuL1ExcessiveOverheadSkipping()
     {
-        $this->performExcessiveOverheadSkippingTest(new APCuL1('overhead'));
+        $this->performExcessiveOverheadSkippingTest($this->l1Factory()->create('apcu', 'overhead'));
     }
 
     public function testSQLiteL1ExcessiveOverheadSkipping()
     {
-        $this->performExcessiveOverheadSkippingTest(new SQLiteL1());
+        $this->performExcessiveOverheadSkippingTest($this->l1Factory()->create('sqlite'));
     }
 
     public function testAPCuL1IntegratedExpiration()
     {
-        $l1 = new APCuL1('expiration');
+        $l1 = $this->l1Factory()->create('apcu', 'expiration');
         $this->performIntegratedExpiration($l1);
     }
 
     public function testStaticL1IntegratedExpiration()
     {
-        $l1 = new StaticL1();
+        $l1 = $this->l1Factory()->create('static');
         $this->performIntegratedExpiration($l1);
     }
 
     public function testSQLiteL1IntegratedExpiration()
     {
-        $l1 = new SQLiteL1();
+        $l1 = $this->l1Factory()->create('sqlite');
         $this->performIntegratedExpiration($l1);
     }
 
@@ -963,10 +1018,10 @@ class LCacheTest extends \PHPUnit_Extensions_Database_TestCase
     public function testSQLiteL1SchemaErrorHandling()
     {
         $pool_name = uniqid('', true) . '-' . mt_rand();
-        $l1_a = new SQLiteL1($pool_name);
+        $l1_a = $this->l1Factory()->create('sqlite', $pool_name);
 
         // Opening a second instance of the same pool should work.
-        $l1_b = new SQLiteL1($pool_name);
+        $l1_b = $this->l1Factory()->create('sqlite', $pool_name);
 
         $myaddr = new Address('mybin', 'mykey');
 


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Adds a feature
- [ ] Needs tests - for the new classes.

### Summary
Draft Implementation of https://github.com/lcache/lcache/issues/63

### Description
We have a different classes that handle the L1 states.
Current implementations are: APCu, Static and NULL.
Maybe add SQLite one.

Update:
Improved in-line docks.

Based on discussion in the issue, decided to go with constructor injection for both pool and state StateL1 handler instance for all L1Cache drivers.

Added a factory to simplify the construction of any L1 instance, as we need to inject more dependencies now. Moved the POOL value generation in the factory (for now).

Re-factored tests to use the factory instead of directly instantiating the concrete L1 instances.