### PR TITLE
SQLite filename will depend on schema definition strings

### DIFF
--- a/src/SQLiteL1.php
+++ b/src/SQLiteL1.php
@@ -54,7 +54,7 @@ class SQLiteL1 extends L1
 
     protected static function getDatabaseHandle($pool)
     {
-        $schemaId = md5(implode(';', self::schemaStatements()));
+        $schemaId = substr(hash('sha512', implode(';', self::schemaStatements())), 0, 20);
         $path = join(DIRECTORY_SEPARATOR, array(sys_get_temp_dir(), "lcache-$pool-$schemaId"));
         $dbh = new \PDO('sqlite:' . $path . '.sqlite3');
         $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
### Overview
This pull request:

- [x] Implements changes described in issue #66 
- [x] Adds a feature - SQLite file-name to depend on schema, so schema changes will reflect in new schema to be created from scratch.

### Summary
There is a new utility that holds all the SQL queries needed to create the schema. 
Based on them a hash is generated and added to the file name, making it unique.
